### PR TITLE
Fix COSMO errors

### DIFF
--- a/COSMO/test.jl
+++ b/COSMO/test.jl
@@ -2,4 +2,4 @@ using ConvexTests, COSMO
 
 @info "Starting COSMO tests"
 
-do_tests("COSMO", () -> COSMO.Optimizer(verbose=false, eps_abs=1e-6, eps_rel=1e-6); exclude = [r"mip", r"dual"], description = "Tests run with `eps_abs=1e-6` and `eps_rel=1e-6`.")
+do_tests("COSMO", () -> COSMO.Optimizer(decompose = false, max_iter = 40000, verbose = false, eps_abs = 5e-7, eps_rel = 5e-7); exclude = [r"mip", r"dual"], description = "Tests run with `eps_abs=1e-6` and `eps_rel=1e-6`.")


### PR DESCRIPTION
Using slighly different solver options should fix most of the errors when the test problems are solved with [COSMO.jl](https://github.com/oxfordcontrol/COSMO.jl). 

## Current errors:

### LPs
- The errors disappear when the number of maximum iterations is increased to ~10000. As COSMO is using only first-order information and the tolerances are set to `1e-6` it will need more iterations then the default `max_iter = 2500` 

### SOCP
- This was caused because the maximum number of iterations was hit and the residuals were around `1e-5`, so slightly above the required solver tolerance, but accurate enough for `atol`. I changed the MOI-wrapper to return the solution in such cases. (see commit: https://github.com/oxfordcontrol/COSMO.jl/commit/439f218cdfb0f6992d37d364e90917097d80ca53)

### SDPs
- **sdp_sigma_max_atom**: The LMI constraint is chordal and structured, so COSMO will try to decompose the LMI.  This caused a bug that I fixed here: https://github.com/oxfordcontrol/COSMO.jl/commit/fda29e161fe03f5f4a9ac1d9d1184efa8f544fa2
The decomposition now works fine.
- **sdp_Partial_trace**: Again caused by COSMO trying to decompose the LMI constraint. This is actually an interesting edge case that I haven't considered. The problem has a cascaded LMI constraint in its conic form: `A = [B 0; 0 0] >= 0` where `B >= 0`. I am not sure atm how to efficiently check for these cases. That's why I turned the decomposition off for this testset, i.e. `decomp = false`. 
- **sdp_sdp_constraints**: The problem suffers from very slow convergence. That's why I slightly increased the tolerances to `5e-7` and `max_iter = 40000`. I need to take a closer look to see what can be done to speed it up.