### PR TITLE
Update new parameters for ProxSDP

### DIFF
--- a/ProxSDP/test.jl
+++ b/ProxSDP/test.jl
@@ -1,4 +1,7 @@
 using ConvexTests, ProxSDP
 
 @info "Starting ProxSDP tests"
-do_tests("ProxSDP", () -> ProxSDP.Optimizer(tol_primal=1e-6, tol_dual=1e-6); exclude = [r"mip", r"exp"], description="Tests run with `tol_primal=1e-6` and `tol_dual=1e-6`.")
+do_tests("ProxSDP", () -> ProxSDP.Optimizer(
+    tol_gap = 5e-8, tol_feasibility = 1e-7, max_iter = 100_000_000, time_limit = 100.0
+); exclude = [r"mip", r"exp"], description =
+"Tests run with `tol_gap = 5e-8`, `tol_feasibility = 1e-7`, `max_iter = 100_000_000` and `time_limit = 100.0`.")


### PR DESCRIPTION
Designed to run in 30 minutes with version 1.6.0.
Partial solution for: https://github.com/mariohsouto/ProxSDP.jl/issues/64

@ericphanson if needed we can reduce the time limit from 100s to 90s.

cc @mariohsouto

local results:
```julia
[ Info: Starting ProxSDP tests
┌ Warning: Problem status DUAL_INFEASIBLE; solution may be inaccurate.
└ @ Convex C:\Users\joaquimgarcia\.julia\packages\Convex\aYxJA\src\solution.jl:252
┌ Warning: Problem status DUAL_INFEASIBLE; solution may be inaccurate.
└ @ Convex C:\Users\joaquimgarcia\.julia\packages\Convex\aYxJA\src\solution.jl:252
┌ Warning: Problem status INFEASIBLE; solution may be inaccurate.
└ @ Convex C:\Users\joaquimgarcia\.julia\packages\Convex\aYxJA\src\solution.jl:252
┌ Warning: Rational norm generating 18 intermediate constraints.
│       Increasing :max_iters or decreasing solver tolerance
│       may give more accurate solutions
└ @ Convex C:\Users\joaquimgarcia\.julia\packages\Convex\aYxJA\src\atoms\second_order_cone\rationalnorm.jl:86
┌ Warning: Problem status TIME_LIMIT; solution may be inaccurate.
└ @ Convex C:\Users\joaquimgarcia\.julia\packages\Convex\aYxJA\src\solution.jl:252
┌ Warning: Problem not DCP compliant: objective is not DCP
└ @ Convex C:\Users\joaquimgarcia\.julia\packages\Convex\aYxJA\src\problems.jl:44
┌ Warning: Problem status TIME_LIMIT; solution may be inaccurate.
└ @ Convex C:\Users\joaquimgarcia\.julia\packages\Convex\aYxJA\src\solution.jl:252
sdp_sdp_constraints: Test Failed at C:\Users\joaquimgarcia\.julia\packages\Convex\aYxJA\src\problem_depot\problems\sdp.jl:68
  Expression: ≈(p.optval, 1, atol = atol, rtol = rtol)
   Evaluated: 1.0013292134464165 ≈ 1 (atol=0.001, rtol=0.0)
Stacktrace:
 [1] sdp_sdp_constraints(::ConvexTests.ConvexBench.var"#2#3"{var"#1#2"}, ::Val{true}, ::Float64, ::Float64, ::Type{Float64}) at C:\Users\joaquimgarcia\.julia\packages\Convex\aYxJA\src\problem_depot\problems\sdp.jl:68
 [2] macro expansion at C:\Users\joaquimgarcia\.julia\dev\ConvexTests\src\ConvexTests.jl:38 [inlined]
 [3] macro expansion at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.5\Test\src\Test.jl:1115 [inlined]
 [4] macro expansion at C:\Users\joaquimgarcia\.julia\dev\ConvexTests\src\ConvexTests.jl:38 [inlined]
 [5] macro expansion at C:\Users\joaquimgarcia\.julia\packages\TimerOutputs\dVnaw\src\TimerOutput.jl:190 [inlined]
 [6] (::ConvexTests.var"#3#4"{DataType,Float64,Float64,TimerOutputs.TimerOutput,ConvexTests.ConvexBench.var"#2#3"{var"#1#2"}})(::String, ::typeof(Convex.ProblemDepot.sdp_sdp_constraints)) at C:\Users\joaquimgarcia\.julia\dev\ConvexTests\src\ConvexTests.jl:36
K = 30: Test Failed at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:31
  Expression: JuMP.primal_status(model) == MOI.FEASIBLE_POINT
   Evaluated: MathOptInterface.INFEASIBLE_POINT == MathOptInterface.FEASIBLE_POINT
Stacktrace:
 [1] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{SumOfSquares.ScaledDiagonallyDominantConeTriangle}, ::Int64, ::Float64) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:31
 [2] macro expansion at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:41 [inlined]
 [3] macro expansion at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.5\Test\src\Test.jl:1190 [inlined]
 [4] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{SumOfSquares.ScaledDiagonallyDominantConeTriangle}, ::Array{Int64,1}, ::Array{Float64,1}) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:40
K = 30: Test Failed at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:32
  Expression: ≈(JuMP.objective_value(model), expected, atol = atol, rtol = rtol)
   Evaluated: 16.25200224043602 ≈ 21.51 (atol=0.1, rtol=0.0)
Stacktrace:
 [1] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{SumOfSquares.ScaledDiagonallyDominantConeTriangle}, ::Int64, ::Float64) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:32
 [2] macro expansion at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:41 [inlined]
 [3] macro expansion at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.5\Test\src\Test.jl:1190 [inlined]
 [4] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{SumOfSquares.ScaledDiagonallyDominantConeTriangle}, ::Array{Int64,1}, ::Array{Float64,1}) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:40
K = 35: Test Failed at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:31
  Expression: JuMP.primal_status(model) == MOI.FEASIBLE_POINT
   Evaluated: MathOptInterface.INFEASIBLE_POINT == MathOptInterface.FEASIBLE_POINT
Stacktrace:
 [1] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{SumOfSquares.ScaledDiagonallyDominantConeTriangle}, ::Int64, ::Float64) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:31
 [2] macro expansion at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:41 [inlined]
 [3] macro expansion at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.5\Test\src\Test.jl:1190 [inlined]
 [4] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{SumOfSquares.ScaledDiagonallyDominantConeTriangle}, ::Array{Int64,1}, ::Array{Float64,1}) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:40
K = 35: Test Failed at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:32
  Expression: ≈(JuMP.objective_value(model), expected, atol = atol, rtol = rtol)
   Evaluated: 14.624906869128345 ≈ 17.17 (atol=0.1, rtol=0.0)
Stacktrace:
 [1] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{SumOfSquares.ScaledDiagonallyDominantConeTriangle}, ::Int64, ::Float64) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:32
 [2] macro expansion at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:41 [inlined]
 [3] macro expansion at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.5\Test\src\Test.jl:1190 [inlined]
 [4] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{SumOfSquares.ScaledDiagonallyDominantConeTriangle}, ::Array{Int64,1}, ::Array{Float64,1}) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:40
K = 40: Test Failed at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:31
  Expression: JuMP.primal_status(model) == MOI.FEASIBLE_POINT
   Evaluated: MathOptInterface.INFEASIBLE_POINT == MathOptInterface.FEASIBLE_POINT
Stacktrace:
 [1] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{SumOfSquares.ScaledDiagonallyDominantConeTriangle}, ::Int64, ::Float64) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:31
 [2] macro expansion at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:41 [inlined]
 [3] macro expansion at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.5\Test\src\Test.jl:1190 [inlined]
 [4] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{SumOfSquares.ScaledDiagonallyDominantConeTriangle}, ::Array{Int64,1}, ::Array{Float64,1}) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:40
K = 40: Test Failed at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:32
  Expression: ≈(JuMP.objective_value(model), expected, atol = atol, rtol = rtol)
   Evaluated: 11.934396486125493 ≈ 13.2 (atol=0.1, rtol=0.0)
Stacktrace:
 [1] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{SumOfSquares.ScaledDiagonallyDominantConeTriangle}, ::Int64, ::Float64) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:32
 [2] macro expansion at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:41 [inlined]
 [3] macro expansion at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.5\Test\src\Test.jl:1190 [inlined]
 [4] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{SumOfSquares.ScaledDiagonallyDominantConeTriangle}, ::Array{Int64,1}, ::Array{Float64,1}) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:40
K = 45: Test Failed at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:31
  Expression: JuMP.primal_status(model) == MOI.FEASIBLE_POINT
   Evaluated: MathOptInterface.INFEASIBLE_POINT == MathOptInterface.FEASIBLE_POINT
Stacktrace:
 [1] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{SumOfSquares.ScaledDiagonallyDominantConeTriangle}, ::Int64, ::Float64) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:31
 [2] macro expansion at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:41 [inlined]
 [3] macro expansion at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.5\Test\src\Test.jl:1190 [inlined]
 [4] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{SumOfSquares.ScaledDiagonallyDominantConeTriangle}, ::Array{Int64,1}, ::Array{Float64,1}) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:40
K = 45: Test Failed at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:32
  Expression: ≈(JuMP.objective_value(model), expected, atol = atol, rtol = rtol)
   Evaluated: 9.714778391532263 ≈ 9.85 (atol=0.1, rtol=0.0)
Stacktrace:
 [1] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{SumOfSquares.ScaledDiagonallyDominantConeTriangle}, ::Int64, ::Float64) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:32
 [2] macro expansion at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:41 [inlined]
 [3] macro expansion at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.5\Test\src\Test.jl:1190 [inlined]
 [4] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{SumOfSquares.ScaledDiagonallyDominantConeTriangle}, ::Array{Int64,1}, ::Array{Float64,1}) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:40
K = 50: Test Failed at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:31
  Expression: JuMP.primal_status(model) == MOI.FEASIBLE_POINT
   Evaluated: MathOptInterface.INFEASIBLE_POINT == MathOptInterface.FEASIBLE_POINT
Stacktrace:
 [1] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{SumOfSquares.ScaledDiagonallyDominantConeTriangle}, ::Int64, ::Float64) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:31
 [2] macro expansion at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:41 [inlined]
 [3] macro expansion at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.5\Test\src\Test.jl:1190 [inlined]
 [4] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{SumOfSquares.ScaledDiagonallyDominantConeTriangle}, ::Array{Int64,1}, ::Array{Float64,1}) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:40
with γ=3.9 it should be infeasible: Test Failed at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\maxcut.jl:37
  Expression: JuMP.dual_status(model) == MOI.INFEASIBILITY_CERTIFICATE
   Evaluated: MathOptInterface.INFEASIBLE_POINT == MathOptInterface.INFEASIBILITY_CERTIFICATE
Stacktrace:
 [1] macro expansion at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\maxcut.jl:37 [inlined]
 [2] macro expansion at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.5\Test\src\Test.jl:1190 [inlined]
 [3] maxcut_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\maxcut.jl:29
K = 30: Test Failed at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:31
  Expression: JuMP.primal_status(model) == MOI.FEASIBLE_POINT
   Evaluated: MathOptInterface.INFEASIBLE_POINT == MathOptInterface.FEASIBLE_POINT
Stacktrace:
 [1] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{MathOptInterface.PositiveSemidefiniteConeTriangle}, ::Int64, ::Float64) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:31
 [2] macro expansion at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:41 [inlined]
 [3] macro expansion at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.5\Test\src\Test.jl:1190 [inlined]
 [4] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{MathOptInterface.PositiveSemidefiniteConeTriangle}, ::Array{Int64,1}, ::Array{Float64,1}) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:40
K = 30: Test Failed at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:32
  Expression: ≈(JuMP.objective_value(model), expected, atol = atol, rtol = rtol)
   Evaluated: 16.850555334550897 ≈ 21.51 (atol=0.1, rtol=0.0)
Stacktrace:
 [1] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{MathOptInterface.PositiveSemidefiniteConeTriangle}, ::Int64, ::Float64) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:32
 [2] macro expansion at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:41 [inlined]
 [3] macro expansion at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.5\Test\src\Test.jl:1190 [inlined]
 [4] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{MathOptInterface.PositiveSemidefiniteConeTriangle}, ::Array{Int64,1}, ::Array{Float64,1}) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:40
K = 35: Test Failed at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:31
  Expression: JuMP.primal_status(model) == MOI.FEASIBLE_POINT
   Evaluated: MathOptInterface.INFEASIBLE_POINT == MathOptInterface.FEASIBLE_POINT
Stacktrace:
 [1] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{MathOptInterface.PositiveSemidefiniteConeTriangle}, ::Int64, ::Float64) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:31
 [2] macro expansion at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:41 [inlined]
 [3] macro expansion at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.5\Test\src\Test.jl:1190 [inlined]
 [4] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{MathOptInterface.PositiveSemidefiniteConeTriangle}, ::Array{Int64,1}, ::Array{Float64,1}) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:40
K = 35: Test Failed at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:32
  Expression: ≈(JuMP.objective_value(model), expected, atol = atol, rtol = rtol)
   Evaluated: 14.376718966143905 ≈ 17.17 (atol=0.1, rtol=0.0)
Stacktrace:
 [1] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{MathOptInterface.PositiveSemidefiniteConeTriangle}, ::Int64, ::Float64) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:32
 [2] macro expansion at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:41 [inlined]
 [3] macro expansion at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.5\Test\src\Test.jl:1190 [inlined]
 [4] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{MathOptInterface.PositiveSemidefiniteConeTriangle}, ::Array{Int64,1}, ::Array{Float64,1}) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:40
K = 40: Test Failed at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:31
  Expression: JuMP.primal_status(model) == MOI.FEASIBLE_POINT
   Evaluated: MathOptInterface.INFEASIBLE_POINT == MathOptInterface.FEASIBLE_POINT
Stacktrace:
 [1] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{MathOptInterface.PositiveSemidefiniteConeTriangle}, ::Int64, ::Float64) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:31
 [2] macro expansion at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:41 [inlined]
 [3] macro expansion at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.5\Test\src\Test.jl:1190 [inlined]
 [4] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{MathOptInterface.PositiveSemidefiniteConeTriangle}, ::Array{Int64,1}, ::Array{Float64,1}) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:40
K = 40: Test Failed at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:32
  Expression: ≈(JuMP.objective_value(model), expected, atol = atol, rtol = rtol)
   Evaluated: 12.007445045296336 ≈ 13.2 (atol=0.1, rtol=0.0)
Stacktrace:
 [1] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{MathOptInterface.PositiveSemidefiniteConeTriangle}, ::Int64, ::Float64) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:32
 [2] macro expansion at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:41 [inlined]
 [3] macro expansion at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.5\Test\src\Test.jl:1190 [inlined]
 [4] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{MathOptInterface.PositiveSemidefiniteConeTriangle}, ::Array{Int64,1}, ::Array{Float64,1}) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:40
K = 45: Test Failed at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:31
  Expression: JuMP.primal_status(model) == MOI.FEASIBLE_POINT
   Evaluated: MathOptInterface.INFEASIBLE_POINT == MathOptInterface.FEASIBLE_POINT
Stacktrace:
 [1] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{MathOptInterface.PositiveSemidefiniteConeTriangle}, ::Int64, ::Float64) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:31
 [2] macro expansion at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:41 [inlined]
 [3] macro expansion at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.5\Test\src\Test.jl:1190 [inlined]
 [4] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{MathOptInterface.PositiveSemidefiniteConeTriangle}, ::Array{Int64,1}, ::Array{Float64,1}) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:40
K = 45: Test Failed at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:32
  Expression: ≈(JuMP.objective_value(model), expected, atol = atol, rtol = rtol)
   Evaluated: 9.637915074930504 ≈ 9.85 (atol=0.1, rtol=0.0)
Stacktrace:
 [1] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{MathOptInterface.PositiveSemidefiniteConeTriangle}, ::Int64, ::Float64) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:32
 [2] macro expansion at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:41 [inlined]
 [3] macro expansion at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.5\Test\src\Test.jl:1190 [inlined]
 [4] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{MathOptInterface.PositiveSemidefiniteConeTriangle}, ::Array{Int64,1}, ::Array{Float64,1}) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:40
K = 50: Test Failed at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:31
  Expression: JuMP.primal_status(model) == MOI.FEASIBLE_POINT
   Evaluated: MathOptInterface.INFEASIBLE_POINT == MathOptInterface.FEASIBLE_POINT
Stacktrace:
 [1] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{MathOptInterface.PositiveSemidefiniteConeTriangle}, ::Int64, ::Float64) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:31
 [2] macro expansion at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:41 [inlined]
 [3] macro expansion at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.5\Test\src\Test.jl:1190 [inlined]
 [4] options_pricing_test(::Function, ::MathOptInterface.Test.TestConfig{Float64}, ::SumOfSquares.NonnegPolyInnerCone{MathOptInterface.PositiveSemidefiniteConeTriangle}, ::Array{Int64,1}, ::Array{Float64,1}) at C:\Users\joaquimgarcia\.julia\dev\SumOfSquares\test\Tests\options_pricing.jl:40
Test Summary:                                                | Pass  Fail  Total
ProxSDP tests                                                | 2007    20   2027
  Convex                                                     |  393     1    394
    constant                                                 |   28           28
    affine                                                   |  139          139
    socp                                                     |   99           99
    lp                                                       |   62           62
    sdp                                                      |   65     1     66
      sdp_socp_abs_atom                                      |    4            4
      sdp_matrix_frac_atom_both_arguments_variable           |    3            3
      sdp_Complex_Variable_with_complex_equality_constraints |    2            2
      sdp_kron_atom                                          |    2            2
      sdp_nuclear_norm_atom                                  |    3            3
      sdp_sum_largest_eigs                                   |    5            5
      sdp_socp_sumsquares_atom                               |    4            4
      sdp_operator_norm_atom                                 |    3            3
      sdp_Issue_198                                          |    3            3
      sdp_Complex_Semidefinite_constraint                    |    2            2
      sdp_lambda_min_atom                                    |    3            3
      sdp_Partial_trace                                      |    9            9
      sdp_Real_Variables_with_complex_equality_constraints   |    1            1
      sdp_sdp_constraints                                    |          1      1
      sdp_sigma_max_atom                                     |    3            3
      sdp_dual_lambda_max_atom                               |    6            6
      sdp_matrix_frac_atom                                   |    3            3
      sdp_socp_norm2_atom                                    |    4            4
      sdp_sdp_variables                                      |    5            5
  SumOfSquares                                               | 1614    19   1633
    socp                                                     |  439     9    448
      sdsos_term_fixed                                       |   44           44
      sdsos_univariate_quadratic                             |   53           53
      sdsos_horn                                             |    3            3
      sdsos_scaled_univariate_quadratic                      |   53           53
      sdsos_univariate_sum                                   |   34           34
      sdsos_quartic_comparison                               |    2            2
      sdsos_scaled_bivariate_quadratic                       |   53           53
      sdsos_concave_then_convex_cubic                        |   13           13
      sdsos_cheby_univariate_quadratic                       |   53           53
      sdsos_term                                             |   44           44
      sdsos_quartic_constant                                 |   33           33
      sdsos_options_pricing                                  |    1     9     10
        K = 30                                               |          2      2
        K = 35                                               |          2      2
        K = 40                                               |          2      2
        K = 45                                               |          2      2
        K = 50                                               |    1     1      2
      sdsos_bivariate_quadratic                              |   53           53
    lp                                                       |  501          501
    sdp                                                      |  674    10    684
      sosdemo5_infeasible                                    |    1            1
      simple_matrix                                          |    6            6
      sos_concave_then_convex_cubic                          |   13           13
      sos_term_fixed                                         |   44           44
      rearrangement                                          |   25           25
      maxcut                                                 |    1     1      2
        with γ=3.9 it should be infeasible                   |          1      1
        with γ=4.1 it should be feasible                     |    1            1
      sos_term                                               |   44           44
      sos_scaled_bivariate_quadratic                         |   53           53
      quartic_ideal_rem                                      |    1            1
      sosdemo5_feasible                                      |    1            1
      chebyshev                                              |    4            4
      sosdemo9                                               |    2            2
      sos_univariate_quadratic                               |   53           53
      sos_cheby_univariate_quadratic                         |   53           53
      quartic_ideal                                          |    9            9
      quartic_feasible_lyapunov_switched_system              |    7            7
      sos_horn                                               |    5            5
      BPT12e399_rem                                          |   48           48
      quadratic_infeasible_lyapunov_switched_system          |    6            6
      quadratic_feasible_scaled_lyapunov_switched_system     |    7            7
      quartic_ideal_4                                        |    9            9
      quadratic_infeasible_scaled_lyapunov_switched_system   |    6            6
      quadratic_feasible_lyapunov_switched_system            |    7            7
      sos_scaled_univariate_quadratic                        |   53           53
      motzkin                                                |    4            4
      sosdemo10                                              |    2            2
      BPT12e399_maxdegree                                    |   56           56
      quartic_infeasible_lyapunov_switched_system            |    6            6
      sos_options_pricing                                    |    1     9     10
        K = 30                                               |          2      2
        K = 35                                               |          2      2
        K = 40                                               |          2      2
        K = 45                                               |          2      2
        K = 50                                               |    1     1      2
      sos_quartic_constant                                   |   33           33
      quartic_infeasible_scaled_lyapunov_switched_system     |    6            6
      sos_univariate_sum                                     |   34           34
      sos_bivariate_quadratic                                |   53           53
      choi                                                   |    2            2
      quartic_feasible_scaled_lyapunov_switched_system       |    7            7
      quartic_ideal_4_rem                                    |    9            9
      sos_quartic_comparison                                 |    2            2
      quartic_ideal_2_rem                                    |    1            1
1803.427447 seconds (1.02 G allocations: 139.393 GiB, 2.37% gc time)
```